### PR TITLE
Make catalog_dashboard id uniq

### DIFF
--- a/apigee-cf-service-broker/helpers/catalog_data.js
+++ b/apigee-cf-service-broker/helpers/catalog_data.js
@@ -21,16 +21,21 @@
  */
 
 var config = require('../helpers/config')
+const uuidv4 = require('uuid/v4')
 
 const ORG_GUID = 'A98CCB00-549B-458F-A627-D54C5E860519';
 const MICRO_GUID = 'D4D617E1-B4F9-49C7-91C8-52AB9DE8C18F';
 const MICRO_CORESIDENT_GUID = 'BF677Y2P-H01Y-99SZ-0YU8-FG7A04B5CVW3';
+const BROKER_ID = '5E3F917B-9225-4BE4-802F-8F1491F714C0'
+
+// Make dashboard ID uniq 
+const dashboard_client = uuidv4();
 
 // service catalog - TODO: this should be configurable
 function getServiceCatalog () {
   return [
     {
-      id: '5E3F917B-9225-4BE4-802F-8F1491F714C0',
+      id: BROKER_ID,
       name: 'apigee-edge',
       description: 'Apigee Edge API Platform',
       bindable: true,
@@ -75,7 +80,7 @@ function getServiceCatalog () {
         }
       ],
       dashboard_client: {
-        id: 'apigee-dashboard-client-id',
+        id: dashboard_client,
         secret: 'secret code phrase',
         redirect_uri: 'https://enterprise.apigee.com'
       }

--- a/apigee-cf-service-broker/package.json
+++ b/apigee-cf-service-broker/package.json
@@ -32,6 +32,7 @@
     "nconf": "^0.8.2",
     "request": "^2.67.0",
     "swagger-parser": "^3.4.0",
+    "uuid":"^3.3.2",
     "xmlbuilder": "^4.2.1",
     "xmldom": "^0.1.22"
   },


### PR DESCRIPTION
For PCF tile upgrade, we  need to deploy a broker with uniq dashboard_id. Generated UUID looks like a good option here. 
Also this fix will allow to deploy several service-brokers in the same foundation, but to use them exact service broker should be specified with `-b` option. 